### PR TITLE
Fix autogen on CentOS 5.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,7 @@ dnl Checks for programs.
 dnl -----------------------------------------------
 
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_PROG_CXX
 AM_PROG_LIBTOOL
 AM_SANITY_CHECK


### PR DESCRIPTION
$ bash autogen.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
test/Makefile.am: C objects in subdir but`AM_PROG_CC_C_O' not in `configure.ac'
autoreconf: automake failed with exit status: 1

Adding AM_PROG_CC_C_O to configure.ac solves this.
